### PR TITLE
Support for user preferences like prefers-reduced-motion and prefers-color-scheme

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["vecdv"]
+  "sandboxes": ["vecdv", "5gwso"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["vecdv", "5gwso"]
+  "sandboxes": ["vecdv"]
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,13 +2,13 @@ import * as THREE from "three"
 import { Canvas, useFrame, useThree } from "react-three-fiber"
 import React, { Suspense, useRef } from "react"
 import { ContactShadows } from "@react-three/drei"
-import { A11y, useA11y, A11yAnnouncer } from "../../"
+import { A11y, useA11y, A11yAnnouncer, A11yUserPreferences, useUserPreferences } from "../../"
 import { ResizeObserver } from "@juggle/resize-observer"
 import { proxy, useProxy } from "valtio"
 import { EffectComposer, SSAO, SMAA } from "@react-three/postprocessing"
 import { Badge } from "@pmndrs/branding"
 
-const state = proxy({ dark: false, active: 0, rotation: 0, disabled: true })
+const state = proxy({ dark: false, active: 0, rotation: 0, disabled: false })
 const geometries = [
   new THREE.SphereBufferGeometry(1, 32, 32),
   new THREE.TetrahedronBufferGeometry(1.5),
@@ -88,18 +88,26 @@ function Shape({ index, active, ...props }) {
   const snap = useProxy(state)
   const vec = new THREE.Vector3()
   const ref = useRef()
+  const userPref = useUserPreferences()
   useFrame((state, delta) => {
     if (snap.disabled) {
       return
     }
-    const s = active ? 2 : 1
-    ref.current.scale.lerp(vec.set(s, s, s), 0.1)
-    ref.current.rotation.y = ref.current.rotation.x += delta / (active ? 1.5 : 4)
-    ref.current.position.y = active ? Math.sin(state.clock.elapsedTime) / 2 : 0
+    if (userPref.prefersReducedMotion) {
+      const s = active ? 2 : 1
+      ref.current.scale.set(s, s, s)
+      ref.current.rotation.y = ref.current.rotation.x = active ? 1.5 : 4
+      ref.current.position.y = 0
+    } else {
+      const s = active ? 2 : 1
+      ref.current.scale.lerp(vec.set(s, s, s), 0.1)
+      ref.current.rotation.y = ref.current.rotation.x += delta / (active ? 1.5 : 4)
+      ref.current.position.y = active ? Math.sin(state.clock.elapsedTime) / 2 : 0
+    }
   })
   return (
     <mesh rotation-y={index * 2000} ref={ref} {...props} geometry={geometries[index]}>
-      <meshPhongMaterial />
+      <meshPhongMaterial color={userPref.prefersDarkScheme ? "#000000" : "#ffffff"} />
     </mesh>
   )
 }
@@ -109,7 +117,14 @@ function Carroussel() {
   const snap = useProxy(state)
   const group = useRef()
   const radius = Math.min(6, viewport.width / 5)
-  useFrame(() => (group.current.rotation.y = THREE.MathUtils.lerp(group.current.rotation.y, snap.rotation - Math.PI / 2, 0.1)))
+  const userPref = useUserPreferences()
+  useFrame(() => {
+    if (userPref.prefersReducedMotion) {
+      group.current.rotation.y = snap.rotation - Math.PI / 2
+    } else {
+      group.current.rotation.y = THREE.MathUtils.lerp(group.current.rotation.y, snap.rotation - Math.PI / 2, 0.1)
+    }
+  })
   return (
     <group ref={group}>
       {["sphere", "pyramid", "donut", "octahedron", "icosahedron"].map((name, i) => (
@@ -131,43 +146,45 @@ export default function App() {
   return (
     <main className={snap.dark ? "dark" : "bright"}>
       <Canvas resize={{ polyfill: ResizeObserver }} camera={{ position: [0, 0, 15], near: 4, far: 30 }} pixelRatio={[1, 1.5]}>
-        <pointLight position={[100, 100, 100]} intensity={snap.disabled ? 0.2 : 0.5} />
-        <pointLight position={[-100, -100, -100]} intensity={1.5} color="red" />
-        <ambientLight intensity={snap.disabled ? 0.2 : 0.8} />
-        <group position-y={2}>
-          <Nav left />
-          <Nav />
-          <Carroussel />
-          <Floor />
-          <A11y
-            role="button"
-            description="Light lowering button"
-            pressedDescription="Light lowering button, activated"
-            actionCall={() => (state.dark = !snap.dark)}
-            activationMsg="Lower light enabled"
-            deactivationMsg="Lower light disabled"
-            disabled={snap.disabled}
-            debug={true}
-            a11yElStyle={{ marginLeft: "-40px" }}>
-            <ToggleButton position={[0, -3, 9]} />
-          </A11y>
-          <A11y
-            role="button"
-            pressed={true}
-            description="Power button, click to disable the scene"
-            pressedDescription="Power button, click to turn on the scene"
-            actionCall={() => (state.disabled = !snap.disabled)}
-            activationMsg="Scene activated"
-            deactivationMsg="Scene disabled">
-            <SwitchButton position={[-3, -5, 7]} />
-          </A11y>
-        </group>
-        {/* <Suspense fallback={null}>
+        <A11yUserPreferences>
+          <pointLight position={[100, 100, 100]} intensity={snap.disabled ? 0.2 : 0.5} />
+          <pointLight position={[-100, -100, -100]} intensity={1.5} color="red" />
+          <ambientLight intensity={snap.disabled ? 0.2 : 0.8} />
+          <group position-y={2}>
+            <Nav left />
+            <Nav />
+            <Carroussel />
+            <Floor />
+            <A11y
+              role="button"
+              description="Light lowering button"
+              pressedDescription="Light lowering button, activated"
+              actionCall={() => (state.dark = !snap.dark)}
+              activationMsg="Lower light enabled"
+              deactivationMsg="Lower light disabled"
+              disabled={snap.disabled}
+              debug={true}
+              a11yElStyle={{ marginLeft: "-40px" }}>
+              <ToggleButton position={[0, -3, 9]} />
+            </A11y>
+            <A11y
+              role="button"
+              pressed={false}
+              description="Power button, click to disable the scene"
+              pressedDescription="Power button, click to turn on the scene"
+              actionCall={() => (state.disabled = !snap.disabled)}
+              activationMsg="Scene activated"
+              deactivationMsg="Scene disabled">
+              <SwitchButton position={[-3, -5, 7]} />
+            </A11y>
+          </group>
+          {/* <Suspense fallback={null}>
           <EffectComposer multisampling={0}>
             <SSAO radius={20} intensity={50} luminanceInfluence={0.1} color="#154073" />
             <SMAA />
           </EffectComposer>
         </Suspense> */}
+        </A11yUserPreferences>
       </Canvas>
       <Badge />
       <A11yAnnouncer />

--- a/src/A11yUserPreferences.tsx
+++ b/src/A11yUserPreferences.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState, useContext } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const A11yUserPreferencesContext = React.createContext({
+  prefersReducedMotion: false,
+  prefersDarkScheme: false,
+});
+
+A11yUserPreferencesContext.displayName = 'A11yUserPreferencesContext';
+
+const useUserPreferences = () => {
+  return useContext(A11yUserPreferencesContext);
+};
+
+export { useUserPreferences };
+
+export const A11yUserPreferences: React.FC<Props> = ({ children }) => {
+  const [a11yPrefersState, setA11yPrefersState] = useState({
+    prefersReducedMotion: false,
+    prefersDarkScheme: false,
+  });
+
+  useEffect(() => {
+    const prefersReducedMotionMediaQuery = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    );
+    const prefersDarkSchemeMediaQuery = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    );
+
+    setA11yPrefersState({
+      prefersReducedMotion: prefersReducedMotionMediaQuery.matches,
+      prefersDarkScheme: prefersDarkSchemeMediaQuery.matches,
+    });
+
+    const handleReducedMotionPrefChange = (e: MediaQueryListEvent) => {
+      setA11yPrefersState({
+        prefersReducedMotion: e.matches,
+        prefersDarkScheme: prefersDarkSchemeMediaQuery.matches,
+      });
+    };
+    const handleDarkSchemePrefChange = (e: MediaQueryListEvent) => {
+      setA11yPrefersState({
+        prefersReducedMotion: prefersReducedMotionMediaQuery.matches,
+        prefersDarkScheme: e.matches,
+      });
+    };
+
+    prefersReducedMotionMediaQuery.addEventListener(
+      'change',
+      handleReducedMotionPrefChange
+    );
+    prefersDarkSchemeMediaQuery.addEventListener(
+      'change',
+      handleDarkSchemePrefChange
+    );
+    return () => {
+      prefersReducedMotionMediaQuery.removeEventListener(
+        'change',
+        handleReducedMotionPrefChange
+      );
+      prefersDarkSchemeMediaQuery.removeEventListener(
+        'change',
+        handleDarkSchemePrefChange
+      );
+    };
+  }, [true]);
+
+  return (
+    <A11yUserPreferencesContext.Provider
+      value={{
+        prefersReducedMotion: a11yPrefersState.prefersReducedMotion,
+        prefersDarkScheme: a11yPrefersState.prefersDarkScheme,
+      }}
+    >
+      {children}
+    </A11yUserPreferencesContext.Provider>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export * from './A11y';
+export * from './A11yUserPreferences';
 export * from './A11yAnnouncer';


### PR DESCRIPTION
Expose the two preference through a context provider to all childrens.

To test it, refer to your OS settings.

I'll update the demo to prevent all animation if prefers-reduced-motion = reduce and enable / disable dark theme based on prefers-color-scheme: dark

If a change is made in the preference while visiting the page, the provider / app will update in consequence.

The idea came from this tweet : https://twitter.com/ericwbailey/status/1351243179060768778
