### PR TITLE
Role image and custom tag for role content

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -220,10 +220,7 @@ export default function App() {
           <ambientLight intensity={snap.disabled ? 0.2 : 0.8} />
           <group position-y={2}>
             <CarrousselAll />
-            <A11y
-              role="image"
-              description="Je suis un test"
-            >
+            <A11y role="image" description="Je suis un test">
               <SwitchButton position={[-3, 3, 7]} />
             </A11y>
             <A11y

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -221,6 +221,12 @@ export default function App() {
           <group position-y={2}>
             <CarrousselAll />
             <A11y
+              role="image"
+              description="Je suis un test"
+            >
+              <SwitchButton position={[-3, 3, 7]} />
+            </A11y>
+            <A11y
               role="togglebutton"
               startPressed={false}
               description="Power button, click to disable the scene"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/a11y",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "👩‍🦯 Provide accessibility support to R3F such as focus indication, keyboard tab index, and screen reader support",
   "keywords": [
     "a11y",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/a11y",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "👩‍🦯 Provide accessibility support to R3F such as focus indication, keyboard tab index, and screen reader support",
   "keywords": [
     "a11y",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-three/a11y",
-  "version": "2.2.0",
+  "version": "2.2.0-alpha.0",
   "description": "👩‍🦯 Provide accessibility support to R3F such as focus indication, keyboard tab index, and screen reader support",
   "keywords": [
     "a11y",

--- a/src/A11y.tsx
+++ b/src/A11y.tsx
@@ -25,6 +25,7 @@ type RoleProps =
       href?: never;
       disabled?: never;
       startPressed?: never;
+      tag?: 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     }
   | {
       role: 'button';
@@ -34,6 +35,7 @@ type RoleProps =
       href?: never;
       disabled?: boolean;
       startPressed?: never;
+      tag?: never;
     }
   | {
       role: 'togglebutton';
@@ -43,6 +45,7 @@ type RoleProps =
       href?: never;
       disabled?: boolean;
       startPressed?: boolean;
+      tag?: never;
     }
   | {
       role: 'link';
@@ -52,6 +55,7 @@ type RoleProps =
       href: string;
       disabled?: never;
       startPressed?: never;
+      tag?: never;
     }
   | {
       role: 'image';
@@ -61,7 +65,8 @@ type RoleProps =
       href?: never;
       disabled?: never;
       startPressed?: never;
-  };
+      tag?: never;
+    };
 
 type Props = A11yCommonProps & RoleProps;
 
@@ -94,6 +99,7 @@ export const A11y: React.FC<Props> = ({
   debug = false,
   a11yElStyle,
   startPressed = false,
+  tag = 'p',
   hidden = false,
   ...props
 }) => {
@@ -333,7 +339,7 @@ export const A11y: React.FC<Props> = ({
             tabIndex: tabIndex,
           }
         : null;
-      if ( role === "image" ) {
+      if (role === 'image') {
         return (
           <img
             r3f-a11y="true"
@@ -365,9 +371,10 @@ export const A11y: React.FC<Props> = ({
             }}
           />
         );
-      }else{
+      } else {
+        const Tag = tag;
         return (
-          <p
+          <Tag
             r3f-a11y="true"
             {...tabIndexP}
             style={Object.assign(
@@ -395,7 +402,7 @@ export const A11y: React.FC<Props> = ({
             }}
           >
             {description}
-          </p>
+          </Tag>
         );
       }
     }
@@ -409,6 +416,7 @@ export const A11y: React.FC<Props> = ({
     href,
     disabled,
     startPressed,
+    tag,
     actionCall,
     focusCall,
   ]);

--- a/src/A11y.tsx
+++ b/src/A11y.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useContext } from 'react';
 import { useThree } from '@react-three/fiber';
 import useAnnounceStore from './announceStore';
 import { useA11ySectionContext } from './A11ySection';
+import { stylesHiddenButScreenreadable } from './A11yConsts';
 import { Html } from './Html';
 
 interface A11yCommonProps {
@@ -104,19 +105,9 @@ export const A11y: React.FC<Props> = ({
   ...props
 }) => {
   let constHiddenButScreenreadable = Object.assign(
-    {
-      opacity: debug ? 1 : 0,
-      borderRadius: '50%',
-      width: '50px',
-      height: '50px',
-      overflow: 'hidden',
-      transform: 'translateX(-50%) translateY(-50%)',
-      display: 'inline-block',
-      userSelect: 'none' as const,
-      WebkitUserSelect: 'none' as const,
-      WebkitTouchCallout: 'none' as const,
-      margin: 0,
-    },
+    {},
+    stylesHiddenButScreenreadable,
+    { opacity: debug ? 1 : 0 },
     a11yElStyle
   );
 

--- a/src/A11y.tsx
+++ b/src/A11y.tsx
@@ -444,7 +444,7 @@ export const A11y: React.FC<Props> = ({
 
   const section = useA11ySectionContext();
   let portal = {};
-  if (section instanceof HTMLElement) {
+  if (section.current instanceof HTMLElement) {
     portal = { portal: section };
   }
 

--- a/src/A11y.tsx
+++ b/src/A11y.tsx
@@ -5,7 +5,7 @@ import { useA11ySectionContext } from './A11ySection';
 import { Html } from './Html';
 
 interface A11yCommonProps {
-  role: 'button' | 'togglebutton' | 'link' | 'content';
+  role: 'button' | 'togglebutton' | 'link' | 'content' | 'image';
   children: React.ReactNode;
   description: string;
   tabIndex?: number;
@@ -52,7 +52,16 @@ type RoleProps =
       href: string;
       disabled?: never;
       startPressed?: never;
-    };
+    }
+  | {
+      role: 'image';
+      activationMsg?: never;
+      deactivationMsg?: never;
+      actionCall?: never;
+      href?: never;
+      disabled?: never;
+      startPressed?: never;
+  };
 
 type Props = A11yCommonProps & RoleProps;
 
@@ -136,7 +145,7 @@ export const A11y: React.FC<Props> = ({
       overHtml.current = true;
     }
     if (overHtml.current || overMesh.current) {
-      if (role !== 'content' && !disabled) {
+      if (role !== 'content' && role !== 'image' && !disabled) {
         domElement.style.cursor = 'pointer';
       }
       setA11yState({
@@ -324,37 +333,71 @@ export const A11y: React.FC<Props> = ({
             tabIndex: tabIndex,
           }
         : null;
-      return (
-        <p
-          r3f-a11y="true"
-          {...tabIndexP}
-          style={Object.assign(
-            constHiddenButScreenreadable,
-            hidden
-              ? { visibility: 'hidden' as const }
-              : { visibility: 'visible' as const }
-          )}
-          onPointerOver={handleOnPointerOver}
-          onPointerOut={handleOnPointerOut}
-          onBlur={() => {
-            setA11yState({
-              hovered: a11yState.hovered,
-              focused: false,
-              pressed: a11yState.pressed,
-            });
-          }}
-          onFocus={() => {
-            if (typeof focusCall === 'function') focusCall();
-            setA11yState({
-              hovered: a11yState.hovered,
-              focused: true,
-              pressed: a11yState.pressed,
-            });
-          }}
-        >
-          {description}
-        </p>
-      );
+      if ( role === "image" ) {
+        return (
+          <img
+            r3f-a11y="true"
+            src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+            alt={description}
+            {...tabIndexP}
+            style={Object.assign(
+              constHiddenButScreenreadable,
+              hidden
+                ? { visibility: 'hidden' as const }
+                : { visibility: 'visible' as const }
+            )}
+            onPointerOver={handleOnPointerOver}
+            onPointerOut={handleOnPointerOut}
+            onBlur={() => {
+              setA11yState({
+                hovered: a11yState.hovered,
+                focused: false,
+                pressed: a11yState.pressed,
+              });
+            }}
+            onFocus={() => {
+              if (typeof focusCall === 'function') focusCall();
+              setA11yState({
+                hovered: a11yState.hovered,
+                focused: true,
+                pressed: a11yState.pressed,
+              });
+            }}
+          />
+        );
+      }else{
+        return (
+          <p
+            r3f-a11y="true"
+            {...tabIndexP}
+            style={Object.assign(
+              constHiddenButScreenreadable,
+              hidden
+                ? { visibility: 'hidden' as const }
+                : { visibility: 'visible' as const }
+            )}
+            onPointerOver={handleOnPointerOver}
+            onPointerOut={handleOnPointerOut}
+            onBlur={() => {
+              setA11yState({
+                hovered: a11yState.hovered,
+                focused: false,
+                pressed: a11yState.pressed,
+              });
+            }}
+            onFocus={() => {
+              if (typeof focusCall === 'function') focusCall();
+              setA11yState({
+                hovered: a11yState.hovered,
+                focused: true,
+                pressed: a11yState.pressed,
+              });
+            }}
+          >
+            {description}
+          </p>
+        );
+      }
     }
   };
 

--- a/src/A11yConsts.tsx
+++ b/src/A11yConsts.tsx
@@ -1,0 +1,15 @@
+let stylesHiddenButScreenreadable = {
+  opacity: 0,
+  borderRadius: '50%',
+  width: '50px',
+  height: '50px',
+  overflow: 'hidden',
+  transform: 'translateX(-50%) translateY(-50%)',
+  display: 'inline-block',
+  userSelect: 'none' as const,
+  WebkitUserSelect: 'none' as const,
+  WebkitTouchCallout: 'none' as const,
+  margin: 0,
+};
+
+export { stylesHiddenButScreenreadable };

--- a/src/A11ySection.tsx
+++ b/src/A11ySection.tsx
@@ -6,6 +6,7 @@ import React, {
   createRef,
 } from 'react';
 import { useThree } from '@react-three/fiber';
+import { stylesHiddenButScreenreadable } from './A11yConsts';
 
 interface Props {
   children: React.ReactNode;
@@ -42,6 +43,23 @@ export const A11ySection: React.FC<Props> = ({
       el.setAttribute('aria-label', label);
     }
     el.setAttribute('r3f-a11y', 'true');
+    el.setAttribute(
+      'style',
+      (styles => {
+        return Object.keys(styles).reduce(
+          (acc, key) =>
+            acc +
+            key
+              .split(/(?=[A-Z])/)
+              .join('-')
+              .toLowerCase() +
+            ':' +
+            (styles as any)[key] +
+            ';',
+          ''
+        );
+      })(stylesHiddenButScreenreadable)
+    );
     if (description) {
       if (refpDesc.current === null) {
         const pDesc = document.createElement('p');


### PR DESCRIPTION
Add a new role image.

Give the possibility to pass the props tag to A11y components with role content in order to be able to use a custom tag when more appropriate and semantically correct. 

So far limited to 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'; 

