### PR TITLE
add dragThreshold prop to A11y component

### DIFF
--- a/src/A11y.tsx
+++ b/src/A11y.tsx
@@ -15,6 +15,7 @@ interface A11yCommonProps {
   debug?: boolean;
   a11yElStyle?: Object;
   hidden?: boolean;
+  dragThreshold?: number;
 }
 
 type RoleProps =
@@ -102,6 +103,7 @@ export const A11y: React.FC<Props> = ({
   startPressed = false,
   tag = 'p',
   hidden = false,
+  dragThreshold,
   ...props
 }) => {
   let constHiddenButScreenreadable = Object.assign(
@@ -460,7 +462,7 @@ export const A11y: React.FC<Props> = ({
         {...props}
         onClick={e => {
           e.stopPropagation();
-          if (disabled) {
+          if (disabled || (dragThreshold && e.delta > dragThreshold)) {
             return;
           }
           if (role === 'button') {


### PR DESCRIPTION
Adds an optional `dragThreshold` prop to the A11y component. If the onClick event delta is greater than this value, the action event handler doesn't fire. 

I've run into an issue using this library in combination with the [drei MapControls](https://github.com/pmndrs/drei#controls), where drags that start and end on the same A11y target trigger a click event when the user's intention is to just pan the camera. 