### PR TITLE
fix: return [0, 0] from calculatePosition if camera projection fails

### DIFF
--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -23,6 +23,9 @@ function calculatePosition(
 ) {
   const objectPos = v1.setFromMatrixPosition(el.matrixWorld);
   objectPos.project(camera);
+  if (isNaN(objectPos.x) || isNaN(objectPos.y)) {
+    return [0, 0];
+  }
   const widthHalf = size.width / 2;
   const heightHalf = size.height / 2;
   return [


### PR DESCRIPTION
Partially resolves https://github.com/pmndrs/react-three-a11y/issues/45#issuecomment-1879572601 (bug from last bullet point)