### PR TITLE
Fix: Improve <Html> functional purity

### DIFF
--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -86,7 +86,7 @@ export const Html = React.forwardRef(
   ) => {
     const { gl, camera, scene, size } = useThree();
     const [el] = React.useState<HTMLDivElement>(() => document.createElement('div'));
-    const root = React.useRef<ReactDOM.Root>(null);
+    const root = React.useRef<ReactDOM.Root>(null!);
     const group = React.useRef<Group>(null!);
     const oldZoom = React.useRef(0);
     const oldPosition = React.useRef([0, 0]);

--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -9,7 +9,7 @@ import {
   PerspectiveCamera,
   OrthographicCamera,
 } from 'three';
-import { type Assign } from 'utility-types';
+import { Assign } from 'utility-types';
 import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber';
 
 const v1 = new Vector3();

--- a/src/Html.tsx
+++ b/src/Html.tsx
@@ -9,7 +9,7 @@ import {
   PerspectiveCamera,
   OrthographicCamera,
 } from 'three';
-import { Assign } from 'utility-types';
+import { type Assign } from 'utility-types';
 import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber';
 
 const v1 = new Vector3();
@@ -67,7 +67,7 @@ export interface HtmlProps
     'ref'
   > {
   eps?: number;
-  portal?: React.MutableRefObject<HTMLElement>;
+  portal?: React.RefObject<HTMLElement>;
   zIndexRange?: Array<number>;
 }
 
@@ -84,19 +84,17 @@ export const Html = React.forwardRef(
     }: HtmlProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const gl = useThree(({ gl }) => gl);
-    const camera = useThree(({ camera }) => camera);
-    const scene = useThree(({ scene }) => scene);
-    const size = useThree(({ size }) => size);
-    const [el] = React.useState(() => document.createElement('div'));
-    const root = React.useMemo(() => ReactDOM.createRoot(el), [el]);
-    const group = React.useRef<Group>(null);
+    const { gl, camera, scene, size } = useThree();
+    const [el] = React.useState<HTMLDivElement>(() => document.createElement('div'));
+    const root = React.useRef<ReactDOM.Root>(null);
+    const group = React.useRef<Group>(null!);
     const oldZoom = React.useRef(0);
     const oldPosition = React.useRef([0, 0]);
     const target = portal?.current ?? gl.domElement.parentNode;
 
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {        
       if (group.current) {
+        const currRoot = (root.current = ReactDOM.createRoot(el));
         scene.updateMatrixWorld();
         const vec = calculatePosition(group.current, camera, size);
         el.style.cssText = `position:absolute;top:0;left:0;transform:translate3d(${vec[0]}px,${vec[1]}px,0);transform-origin:0 0;`;
@@ -104,8 +102,8 @@ export const Html = React.forwardRef(
           target.appendChild(el);
         }
         return () => {
-          if (target) target.removeChild(el);
-          root.unmount();
+            if (target) target.removeChild(el);
+            currRoot.unmount();
         };
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -117,10 +115,10 @@ export const Html = React.forwardRef(
         transform: 'none',
         ...style,
       };
-    }, [style, size]);
+    }, [style]);
 
     React.useLayoutEffect(() => {
-      root.render(
+      root.current?.render(
         <div
           ref={ref}
           style={styles}
@@ -158,3 +156,4 @@ export const Html = React.forwardRef(
     return <group {...props} ref={group} />;
   }
 );
+


### PR DESCRIPTION
Currently, when using [React's \<StrictMode\>](https://react.dev/reference/react/StrictMode), ReactDOM.createRoot() is called twice on the same root. This indicates an issue with functional purity. In addition, when \<A11y\> components are removed from the React tree, updates to the removed root may be attempted.

These changes are based on [the most up-to-date drei Html component](https://github.com/pmndrs/drei/blob/master/src/web/Html.tsx), and are likely to fix [Issue 53](https://github.com/pmndrs/react-three-a11y/issues/53).

- Change UseEffect to UseLayoutEffect:
    -  This change ensures that render() isn't called on an unmounted root.
- Move root creation into UseLayoutEffect and store root using useRef():
    - This change ensures that createRoot() isn't called multiple times on an already mounted container.
- Small syntax/depreciated changes:
    - ~~Adds type prefix to Assign import~~.
    - Changes depreciated MutableRefObject type to RefObject.
    - Condenses useThree() hooks.
    - Removes unused size effect dependency.
    
  EDIT: the type keyword was removed and the value passed into root's useRef() was changed to null! in order to support the software running on CodeSandbox. 